### PR TITLE
M-01: introduce `VestingPeriodParam`

### DIFF
--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -207,7 +207,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
     function createSchedule(
         address beneficiary,
         bool isCancellable,
-        VestingPeriod[] calldata periods
+        VestingPeriodParam[] calldata periods
     ) external override onlyRole(VESTING_ADMIN_ROLE) returns (uint32 scheduleId) {
         // Validate inputs
         if (beneficiary == address(0)) revert LibErrors.InvalidAddress();
@@ -225,7 +225,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
         uint256 totalAmount = 0;
         uint256 periodsLength = periods.length;
         for (uint256 i = 0; i < periodsLength; ) {
-            VestingPeriod calldata period = periods[i];
+            VestingPeriodParam calldata period = periods[i];
 
             // Validate period amount
             if (period.amount == 0) revert LibErrors.ZeroAmount();
@@ -243,8 +243,16 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
                 revert IVestingVaultErrors.InvalidStartTime(i, period.startPeriod);
             }
 
+            VestingPeriod memory newPeriod = VestingPeriod({
+                startPeriod: period.startPeriod,
+                endPeriod: period.endPeriod,
+                cliff: period.cliff,
+                amount: period.amount,
+                claimedAmount: 0
+            });
+
             // Store period and accumulate total amount
-            newSchedule.periods.push(period);
+            newSchedule.periods.push(newPeriod);
             totalAmount += period.amount;
             unchecked {
                 ++i;

--- a/contracts/vaults/interfaces/IVestingVault.sol
+++ b/contracts/vaults/interfaces/IVestingVault.sol
@@ -40,6 +40,22 @@ interface IVestingVault {
     }
 
     /**
+     * @notice Represents vesting period parameters for schedule creation
+     * @dev This is the DTO for VestingPeriod, used for creating new schedules. It does not include the `claimedAmount`
+     *      property, which is only relevant after the schedule is created.
+     * @param startPeriod The start time of this vesting period
+     * @param endPeriod The end time of this vesting period
+     * @param cliff The cliff period for this vesting period
+     * @param amount The total amount of tokens in this vesting period (must be greater than zero)
+     */
+    struct VestingPeriodParam {
+        uint64 startPeriod;
+        uint64 endPeriod;
+        uint64 cliff;
+        uint256 amount;
+    }
+
+    /**
      * @notice Represents a complete vesting schedule for a beneficiary
      * @param id Global unique identifier for this schedule
      * @param beneficiary Owner of this schedule
@@ -121,7 +137,7 @@ interface IVestingVault {
     function createSchedule(
         address beneficiary,
         bool isCancellable,
-        VestingPeriod[] calldata periods
+        VestingPeriodParam[] calldata periods
     ) external returns (uint32 scheduleId);
 
     /**


### PR DESCRIPTION
Create a new `VestingPeriodParam` struct for schedule creation that omits the `claimedAmount` field, improving UX by preventing users from setting a non-zero `claimedAmount`. The contract now takes `VestingPeriodParam` as input for `createSchedule`, and uses its values to initialize a `VestingPeriod` for storage with `claimedAmount` set to zero.