### PR TITLE
N-01: `msg.sender` consistency

### DIFF
--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -296,7 +296,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
         committedTokens += totalAmount;
 
         // Emit event with the complete schedule
-        emit VestingScheduleCreated(msg.sender, beneficiary, scheduleId, newSchedule);
+        emit VestingScheduleCreated(_msgSender(), beneficiary, scheduleId, newSchedule);
     }
 
     /**

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -207,7 +207,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
     function createSchedule(
         address beneficiary,
         bool isCancellable,
-        VestingPeriod[] calldata periods
+        VestingPeriodParam[] calldata periods
     ) external override onlyRole(VESTING_ADMIN_ROLE) returns (uint32 scheduleId) {
         // Validate inputs
         if (beneficiary == address(0)) revert LibErrors.InvalidAddress();
@@ -225,7 +225,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
         uint256 totalAmount = 0;
         uint256 periodsLength = periods.length;
         for (uint256 i = 0; i < periodsLength; ) {
-            VestingPeriod calldata period = periods[i];
+            VestingPeriodParam calldata period = periods[i];
 
             // Validate period amount
             if (period.amount == 0) revert LibErrors.ZeroAmount();
@@ -243,8 +243,16 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
                 revert IVestingVaultErrors.InvalidStartTime(i, period.startPeriod);
             }
 
+            VestingPeriod memory newPeriod = VestingPeriod({
+                startPeriod: period.startPeriod,
+                endPeriod: period.endPeriod,
+                cliff: period.cliff,
+                amount: period.amount,
+                claimedAmount: 0
+            });
+
             // Store period and accumulate total amount
-            newSchedule.periods.push(period);
+            newSchedule.periods.push(newPeriod);
             totalAmount += period.amount;
             unchecked {
                 ++i;

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -77,6 +77,24 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
      */
     bytes32 public constant SALVAGE_ROLE = keccak256("SALVAGE_ROLE");
 
+    /**
+     * @notice Maximum relative time threshold for global vesting mode. This means that when the global vesting mode
+     *         is enabled, schedule periods will be limited to starting within the next ≈ 31.7 years after
+     *         `globalVestingStartTime`.
+     *
+     * @dev Prevents accidental use of absolute Unix timestamps instead of relative offsets.
+     *      Value of 1e9 seconds ≈ 31.7 years is considered a sensible upper bound for relative times.
+     */
+    uint256 private constant MAX_RELATIVE_TIME_THRESHOLD = 1e9;
+
+    /**
+     * @notice Maximum duration allowed for any vesting period (start to end time difference).
+     * @dev This constant limits the duration of individual vesting periods to prevent excessively long vesting
+     *      schedules as a result of incorrect input. Applied to both global and individual vesting modes.
+     *      Value of 1.6e9 seconds represents ≈ 50.7 years.
+     */
+    uint256 private constant MAX_DURATION = 1.6e9;
+
     /// State - Immutable
 
     /**
@@ -232,12 +250,19 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
 
             // Validate period times
             if (period.endPeriod <= period.startPeriod) revert IVestingVaultErrors.InvalidEndTime(i, period.endPeriod);
-
+            // Validate maximum duration for vesting period
+            uint256 vestingDuration = period.endPeriod - period.startPeriod;
+            if (vestingDuration > MAX_DURATION) {
+                revert IVestingVaultErrors.InvalidDuration(i, vestingDuration);
+            }
             // Validate cliff doesn't exceed vesting duration
             if (period.cliff > 0 && period.startPeriod + period.cliff > period.endPeriod) {
                 revert IVestingVaultErrors.InvalidCliff(i, period.cliff);
             }
-
+            // In global mode, validate startPeriod isn't accidentally a Unix timestamp
+            if (globalVestingMode && period.startPeriod > MAX_RELATIVE_TIME_THRESHOLD) {
+                revert IVestingVaultErrors.InvalidStartTime(i, period.startPeriod);
+            }
             // In non-global mode, validate start time is not in the past
             if (!globalVestingMode && period.startPeriod < block.timestamp) {
                 revert IVestingVaultErrors.InvalidStartTime(i, period.startPeriod);

--- a/contracts/vaults/interfaces/IVestingVault.sol
+++ b/contracts/vaults/interfaces/IVestingVault.sol
@@ -40,6 +40,22 @@ interface IVestingVault {
     }
 
     /**
+     * @notice Represents vesting period parameters for schedule creation
+     * @dev This is the DTO for VestingPeriod, used for creating new schedules. It does not include the `claimedAmount`
+     *      property, which is only relevant after the schedule is created.
+     * @param startPeriod The start time of this vesting period
+     * @param endPeriod The end time of this vesting period
+     * @param cliff The cliff period for this vesting period
+     * @param amount The total amount of tokens in this vesting period (must be greater than zero)
+     */
+    struct VestingPeriodParam {
+        uint64 startPeriod;
+        uint64 endPeriod;
+        uint64 cliff;
+        uint256 amount;
+    }
+
+    /**
      * @notice Represents a complete vesting schedule for a beneficiary
      * @param id Global unique identifier for this schedule
      * @param beneficiary Owner of this schedule
@@ -121,7 +137,7 @@ interface IVestingVault {
     function createSchedule(
         address beneficiary,
         bool isCancellable,
-        VestingPeriod[] calldata periods
+        VestingPeriodParam[] calldata periods
     ) external returns (uint32 scheduleId);
 
     /**

--- a/contracts/vaults/interfaces/IVestingVaultErrors.sol
+++ b/contracts/vaults/interfaces/IVestingVaultErrors.sol
@@ -71,6 +71,13 @@ interface IVestingVaultErrors {
     error InvalidCliff(uint256 periodIndex, uint256 cliff);
 
     /**
+     * @dev Indicates that the vesting duration (endPeriod - startPeriod) is invalid.
+     * @param periodIndex The index of the vesting period that has an invalid duration.
+     * @param duration The invalid duration that was provided.
+     */
+    error InvalidDuration(uint256 periodIndex, uint256 duration);
+
+    /**
      * @dev Indicates that the schedule index is not valid.
      * @param beneficiary The address of the beneficiary.
      * @param scheduleIndex The invalid schedule index.


### PR DESCRIPTION
fix: use _msgSender() for consistency

The VestingVault contract inherits from Context, which provides an
enhanced middleware. Using _msgSender() instead of msg.sender ensures
consistent sender references throughout the contract.

- Replaced msg.sender with _msgSender() in VestingScheduleCreated event
  emission.
- Maintains consistency with Context pattern.