### PR TITLE
fix(vesting-vault): address Low Severity issues

### DIFF
--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -415,6 +415,7 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
      *
      * Reverts if:
      * - There are no tokens available to be claimed for the specified schedule
+     * - The schedule is cancelled
      *
      * Emits {TokenRelease} events for each period with claimable tokens as part of {_claim}.
      *
@@ -432,6 +433,8 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
         require(schedule.id != 0, LibErrors.NotFound(scheduleId));
         // Validate schedule belongs to caller
         require(_msgSender() == scheduleBeneficiary, LibErrors.UnauthorizedCaller());
+        // Validate schedule is not cancelled
+        require(!schedule.isCancelled, IVestingVaultErrors.CancelledSchedule(scheduleId));
 
         uint256 totalClaimable = 0;
         uint256 numPeriods = schedule.periods.length;
@@ -465,6 +468,7 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
      *
      * Reverts if:
      * - There are no tokens available to be claimed for the specified period
+     * - The schedule is cancelled
      *
      * Emits a {TokenRelease} event as part of {_claim}.
      *
@@ -483,6 +487,8 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
         require(schedule.id != 0, LibErrors.NotFound(scheduleId));
         // Validate schedule belongs to caller
         require(_msgSender() == scheduleBeneficiary, LibErrors.UnauthorizedCaller());
+        // Validate schedule is not cancelled
+        require(!schedule.isCancelled, IVestingVaultErrors.CancelledSchedule(scheduleId));
         // Check if periodIndex is within bounds
         require(
             periodIndex < schedule.periods.length,
@@ -581,6 +587,7 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
      *
      * Reverts if:
      * - There are no tokens available to be released for the specified schedule
+     * - The schedule is cancelled
      *
      * Emits {TokenRelease} events for each period with releasable tokens as part of {_claim}.
      *
@@ -596,6 +603,8 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
         address scheduleBeneficiary = schedule.beneficiary;
         // Validate schedule exists
         require(schedule.id != 0, LibErrors.NotFound(scheduleId));
+        // Validate schedule is not cancelled
+        require(!schedule.isCancelled, IVestingVaultErrors.CancelledSchedule(scheduleId));
 
         uint256 totalReleasable = 0;
         uint256 numPeriods = schedule.periods.length;
@@ -631,6 +640,7 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
      *
      * Reverts if:
      * - There are no tokens available to be released for the specified period
+     * - The schedule is cancelled
      *
      * Emits a {TokenRelease} event as part of {_claim}.
      *
@@ -647,6 +657,8 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
         address scheduleBeneficiary = schedule.beneficiary;
         // Validate schedule exists
         require(schedule.id != 0, LibErrors.NotFound(scheduleId));
+        // Validate schedule is not cancelled
+        require(!schedule.isCancelled, IVestingVaultErrors.CancelledSchedule(scheduleId));
         // Check if periodIndex is within bounds
         require(
             periodIndex < schedule.periods.length,

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -837,13 +837,17 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
     /**
      * @notice Returns the claimable amount for a specific schedule
      * @dev Calculates the sum of vested but unclaimed tokens across all periods
-     *      in the schedule. Returns zero for cancelled schedules.
+     *      in the schedule.
+     *
+     * Returns zero when:
+     * - schedule does not exist (e.g. `scheduleId` is 0),
+     * - schedule is cancelled,
+     * - global vesting mode is enabled but not started
      *
      * @param scheduleId The ID of the schedule
      * @return claimableAmount Amount that can be claimed from the schedule
      */
     function getClaimableAmount(uint256 scheduleId) external view override returns (uint256 claimableAmount) {
-        // If global vesting mode is enabled but not started, return 0
         if (globalVestingMode && !globalVestingStarted) {
             return 0;
         }
@@ -859,7 +863,12 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
     /**
      * @notice Returns the claimable amount for a specific period
      * @dev Calculates the vested but unclaimed tokens for a single period.
-     *      Returns zero for cancelled schedules or invalid period indices.
+     *
+     * Returns zero when:
+     * - schedule does not exist (e.g. `scheduleId` is 0),
+     * - schedule is cancelled,
+     * - global vesting mode is enabled but not started,
+     * - `periodIndex` is out of bounds
      *
      * @param scheduleId The ID of the schedule
      * @param periodIndex The index of the period
@@ -869,7 +878,6 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
         uint256 scheduleId,
         uint256 periodIndex
     ) external view override returns (uint256 claimableAmount) {
-        // If global vesting mode is enabled but not started, return 0
         if (globalVestingMode && !globalVestingStarted) {
             return 0;
         }

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -1112,17 +1112,19 @@ contract VestingVault is Context, BoundedRoleMembership, SalvageCapable, IVestin
      * @notice Internal function to process token release to a beneficiary or admin
      * @dev Transfers tokens and emits events
      *
-     * This function performs an external call, and so it should only be called after all checks and effects
-     * have been performed.
+     * This function performs an external call and contrary to the Checks-Effects-Interactions (CEI) pattern, it has a
+     * side-effect following the transfer. Note that while it doesn't strictly follow the CEI pattern, it is safe to
+     * perform this interaction before the state update, because the `claimedAmount` checks and state-changing
+     * operation (which are a determinant for the transfer) are done before this call, in `_claim` or `cancelSchedule`.
      *
      * @param recipient The token recipient address
      * @param amount The amount to release
      */
     function _processTokenRelease(address recipient, uint256 amount) internal {
-        // Update committed tokens by decreasing the released amount
-        committedTokens -= amount;
-
-        // Transfer tokens
+        // Transfer tokens first (note: safe anti-pattern)
         vestingToken.safeTransfer(recipient, amount);
+
+        // Reduce the committed tokens constraint by the released amount
+        committedTokens -= amount;
     }
 }


### PR DESCRIPTION
#### [L-01: align event emission order in `salvageNFT`](https://github.com/fireblocks/fireblocks-smart-contracts/pull/35) 

- https://github.com/fireblocks/fireblocks-smart-contracts/pull/35/commits/c52d9e721b7592d42bff94fb6f84be70d874af6a

#### L-05: Add cancelled checks to claim/release fns

- Add explicit cancelled schedule checks to claim/release functions that
  have a specific schedule ID as an argument
- Replace NoTokensToClaim with clear CancelledSchedule errors in such
  cases

#### L-07

- https://github.com/fireblocks/fireblocks-smart-contracts/pull/31

#### [L-08: clarify error for non-contract vestingToken_](https://github.com/fireblocks/fireblocks-smart-contracts/commit/8ce7552578e2bb1c8d216a9828249b0b154ed8ce)

- 8ce7552578e2bb1c8d216a9828249b0b154ed8ce

#### L-10: reduce committedTokens after transfer

- Move `committedTokens` update after token transfer in
`_processTokenRelease`.

#### L-11: clarify getter zero-return conditions

- Update function documentation to list the edge case scenarios where
`getClaimableAmount` and `getClaimableAmountForPeriod` return zero,
improving code clarity.