### PR TITLE
fix(salvage-capable): audit recommendations

### DIFF
--- a/contracts/library/Utils/SalvageCapable.sol
+++ b/contracts/library/Utils/SalvageCapable.sol
@@ -74,9 +74,10 @@ abstract contract SalvageCapable is Context {
      * @param amount The amount to be salvaged.
      */
     function salvageERC20(IERC20 token, uint256 amount) external virtual {
+        require(amount > 0, LibErrors.ZeroAmount());
         _authorizeSalvageERC20(address(token), amount);
         emit TokenSalvaged(_msgSender(), address(token), amount);
-        _withdrawERC20(token, _msgSender(), amount);
+        token.safeTransfer(_msgSender(), amount);
     }
 
     /**
@@ -117,22 +118,6 @@ abstract contract SalvageCapable is Context {
         token.safeTransferFrom(address(this), _msgSender(), tokenId);
     }
 
-    /**
-     * @notice An internal function used to withdraw ERC20 tokens in the contract.
-     * @dev Internal function without access restriction.
-     *
-     * Calling Conditions:
-     *
-     * - `amount` is greater than 0.
-     *
-     * @param token The ERC20 asset which is to be withdrawn.
-     * @param recipient The address to which the tokens are to be sent.
-     * @param amount The amount to be withdrawn.
-     */
-    function _withdrawERC20(IERC20 token, address recipient, uint256 amount) internal virtual {
-        require(amount > 0, LibErrors.ZeroAmount());
-        token.safeTransfer(recipient, amount);
-    }
 
     /**
      * @notice This function is designed to be overridden in inheriting contracts.

--- a/contracts/library/Utils/SalvageCapable.sol
+++ b/contracts/library/Utils/SalvageCapable.sol
@@ -113,8 +113,8 @@ abstract contract SalvageCapable is Context {
      */
     function salvageNFT(IERC721 token, uint256 tokenId) external virtual {
         _authorizeSalvageNFT();
-        token.safeTransferFrom(address(this), _msgSender(), tokenId);
         emit NFTSalvaged(_msgSender(), address(token), tokenId);
+        token.safeTransferFrom(address(this), _msgSender(), tokenId);
     }
 
     /**

--- a/contracts/library/Utils/SalvageCapable.sol
+++ b/contracts/library/Utils/SalvageCapable.sol
@@ -121,7 +121,7 @@ abstract contract SalvageCapable is Context {
 
     /**
      * @notice This function is designed to be overridden in inheriting contracts.
-     * @dev Override this function to implement RBAC control.
+     * @dev Override this function to implement Role-Based Access Control.
      *
      * @param salvagedToken The address of the token being salvaged.
      * @param amount The amount of the token being salvaged.
@@ -130,13 +130,13 @@ abstract contract SalvageCapable is Context {
 
     /**
      * @notice This function is designed to be overridden in inheriting contracts.
-     * @dev Override this function to implement RBAC control.
+     * @dev Override this function to implement Role-Based Access Control.
      */
     function _authorizeSalvageGas() internal virtual;
 
     /**
      * @notice This function is designed to be overridden in inheriting contracts.
-     * @dev Override this function to implement RBAC control.
+     * @dev Override this function to implement Role-Based Access Control.
      */
     function _authorizeSalvageNFT() internal virtual;
 }

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -849,7 +849,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
      * - `salvagedToken` is the same as `vestingToken`
      * @param salvagedToken The address of the token being salvaged
      */
-    function _authorizeSalvageERC20(address salvagedToken) internal virtual override {
+    function _authorizeSalvageERC20(address salvagedToken, uint256 /* amount */) internal virtual override {
         require(salvagedToken != address(vestingToken), LibErrors.InvalidAddress());
         _checkRole(SALVAGE_ROLE);
     }


### PR DESCRIPTION
#### refactor: add param to auth hook 

- Change `_authorizeSalvageERC20`  function signature to support "OFT Adapter" contract from https://github.com/fireblocks/fireblocks-smart-contracts/pull/16
- Refactors bundled in 22e4f9a0717835526f63cebf8b33a0198cc5c201

#### L-01: align event emission order in `salvageNFT`

- Aligns event emission order in `salvageNFT` to match other salvage functions
- Moves `NFTSalvaged` event emission after asset transfer in `salvageNFT`

#### N-02: fix redundant "RBAC control" phrasing

- Replace "RBAC control" with "Role-Based Access Control" in three
function comments for `_authorizeSalvageERC20`, `_authorizeSalvageGas`,
and `_authorizeSalvageNFT`.

#### N-05: remove _withdrawERC20 for uniformity
- Remove the `_withdrawERC20` virtual function and move its logic
  into salvageERC20, creating uniform pattern across all salvage
  operations: (validation), authorization check, event emission, and
  transfer.