### PR TITLE
fix(vesting-vault): Address N-03 & L-03

### DIFF
--- a/contracts/library/Errors/LibErrors.sol
+++ b/contracts/library/Errors/LibErrors.sol
@@ -30,6 +30,11 @@ library LibErrors {
     error AccountUnauthorized(address account);
 
     /**
+     * @dev There's no code at `target` (it is not a contract).
+     */
+    error AddressEmptyCode(address target);
+
+    /**
      * @notice Thrown when a Renounce Role is called.
      */
     error RenounceRoleDisabled();

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -134,7 +134,10 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
     /// Functions
 
     /**
-     * @notice Constructs the VestingVault contract
+     * @notice Constructs the VestingVault contract. It receives the token to manage, accounts for RBAC,
+     *         and defines whether to use global vesting mode. The token to manage must be minted, i.e. have a
+     *         non-zero total supply.
+     *
      * @dev Initializer function that sets up the token to manage in the vault, RBAC roles, and Global Vesting Mode.
      *
      * The FORFEITURE_ADMIN_ROLE and SALVAGE_ROLE are not granted at deploy time and must be granted separately when
@@ -143,8 +146,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
      * Calling Conditions:
      *
      * - `vestingToken_` must have bytecode set
-     * - `vestingToken_` must implement the `decimals()` function of ERC20, with a
-     *   return value > 0
+     * - `vestingToken_` must implement the `totalSupply()` function of ERC20, with a return value > 0
      * - `defaultAdmin` must not be the zero address
      * - `vestingAdmin` must not be the zero address
      *
@@ -162,11 +164,11 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
 
         // Validate that vestingToken_ passes common ERC20 implementation checks
         require(vestingToken_.code.length > 0, LibErrors.AddressEmptyCode(vestingToken_));
-        // Check if decimals() function exists and returns > 0
-        (bool success, bytes memory data) = vestingToken_.staticcall(abi.encodeWithSignature("decimals()"));
+        // Check if totalSupply() function exists and returns > 0
+        (bool success, bytes memory data) = vestingToken_.staticcall(abi.encodeWithSignature("totalSupply()"));
         require(success && data.length > 0, LibErrors.InvalidImplementation());
-        uint8 decimals = abi.decode(data, (uint8));
-        require(decimals > 0, LibErrors.InvalidImplementation());
+        uint256 totalSupply = abi.decode(data, (uint256));
+        require(totalSupply > 0, LibErrors.InvalidImplementation());
 
         vestingToken = IERC20(vestingToken_);
         globalVestingMode = globalVestingMode_;

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -135,8 +135,8 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
 
     /**
      * @notice Constructs the VestingVault contract. It receives the token to manage, accounts for RBAC,
-     *         and defines whether to use global vesting mode. The token to manage must be minted, i.e. have a
-     *         non-zero total supply.
+     *         and defines whether to use global vesting mode. The token must be a valid ERC20 contract
+     *         with a non-zero total supply.
      *
      * @dev Initializer function that sets up the token to manage in the vault, RBAC roles, and Global Vesting Mode.
      *
@@ -145,8 +145,8 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
      *
      * Calling Conditions:
      *
-     * - `vestingToken_` must have bytecode set
-     * - `vestingToken_` must implement the `totalSupply()` function of ERC20, with a return value > 0
+     * - `vestingToken_` must be a contract address (non-zero bytecode)
+     * - `vestingToken_` must implement the `totalSupply()` function and return a value > 0
      * - `defaultAdmin` must not be the zero address
      * - `vestingAdmin` must not be the zero address
      *

--- a/contracts/vaults/VestingVault.sol
+++ b/contracts/vaults/VestingVault.sol
@@ -142,7 +142,8 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
      *
      * Calling Conditions:
      *
-     * - `vestingToken_` must have bytecode set and must implement the `decimals()` function of ERC20, with a
+     * - `vestingToken_` must have bytecode set
+     * - `vestingToken_` must implement the `decimals()` function of ERC20, with a
      *   return value > 0
      * - `defaultAdmin` must not be the zero address
      * - `vestingAdmin` must not be the zero address
@@ -160,7 +161,7 @@ contract VestingVault is Context, AccessControl, SalvageCapable, IVestingVault, 
         require(vestingAdmin != address(0), LibErrors.InvalidAddress());
 
         // Validate that vestingToken_ passes common ERC20 implementation checks
-        require(vestingToken_.code.length > 0, LibErrors.InvalidImplementation());
+        require(vestingToken_.code.length > 0, LibErrors.AddressEmptyCode(vestingToken_));
         // Check if decimals() function exists and returns > 0
         (bool success, bytes memory data) = vestingToken_.staticcall(abi.encodeWithSignature("decimals()"));
         require(success && data.length > 0, LibErrors.InvalidImplementation());

--- a/contracts/vaults/interfaces/IVestingVault.sol
+++ b/contracts/vaults/interfaces/IVestingVault.sol
@@ -42,7 +42,7 @@ interface IVestingVault {
     /**
      * @notice Represents a complete vesting schedule for a beneficiary
      * @param id Global unique identifier for this schedule
-     * @param beneficiary Owner of this schedule
+     * @param beneficiary The recipient of vested tokens from this schedule
      * @param isCancellable Whether this schedule can be cancelled by admins
      * @param isCancelled Whether this schedule has been cancelled
      * @param periods Array of vesting periods that comprise this schedule
@@ -99,7 +99,7 @@ interface IVestingVault {
      * @param beneficiary The beneficiary whose schedule was cancelled
      * @param scheduleId The ID of the cancelled schedule
      * @param claimedAmount The amount transferred to beneficiary during cancellation
-     * @param reclaimedAmount The amount reclaimed by the contract
+     * @param reclaimedAmount The amount of unvested tokens transferred to the admin
      */
     event VestingScheduleCancelled(
         address indexed admin,


### PR DESCRIPTION
**N-03: ERC-20 validation to check totalSupply**

- The VestingVault constructor previously excluded valid ERC-20 tokens
that use zero decimals. The validation now checks that `totalSupply()`
exists, has a return value, and this return value is greater than zero,
ensuring the token is minted and compliant without excluding tokens
based on their decimals value.

**L-03: fix misleading documentation**

Update inaccurate comments that could confuse developers about
validation checks, token flow, and role definitions:

- `Schedule.beneficiary`: change "Owner" to "recipient" since
  beneficiaries don't control schedules, only receive tokens
- `VestingScheduleCancelled` event: clarify unvested tokens go to admin,
  not retained by contract
- `constructor`: accurately describe `totalSupply()` validation and
  contract address checks performed